### PR TITLE
fix: skip lit-css transformation for CSS files requested with ?url

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -4,8 +4,10 @@ export const cssModuleRE = new RegExp(`\\.module${CSS_LANGS_RE.source}`)
 export const directRequestRE = /[?&]direct\b/
 
 export const inlineRE = /[?&]inline\b/
+export const transformOnlyRE = /[?&]transform-only\b/
 
 export const isInline = (id: string) => inlineRE.test(id)
+export const isTransformOnly = (id: string) => transformOnlyRE.test(id)
 export const isCssModule = (id: string) => cssModuleRE.test(id)
 export const isDirectCSSRequest = (request: string): boolean =>
   CSS_LANGS_RE.test(request) && directRequestRE.test(request)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { type Plugin, isCSSRequest } from 'vite';
 import { createFilter } from '@rollup/pluginutils';
-import { isCssModule, isDirectCSSRequest, isInline } from './core/constants';
+import { isCssModule, isDirectCSSRequest, isInline, isTransformOnly } from './core/constants';
 import { Engines, Engine, engines } from './core/engines';
 import { sanitize } from './core/sanitize';
 import { type Plugin as RollupPlugin } from 'rollup';
@@ -33,7 +33,8 @@ export default function lit(options: Options = {}): Plugin {
         if (
           isDirectCSSRequest(id) ||
           !filter(id) ||
-          isInline(id)
+          isInline(id) ||
+          isTransformOnly(id)
         ) {
           return cssPostTransformFn.call(this, css, id, ...args);
         }

--- a/test/__snapshots__/vite.test.ts.snap
+++ b/test/__snapshots__/vite.test.ts.snap
@@ -39,3 +39,23 @@ export {
 };
 "
 `;
+
+exports[`litcss plugin > fixtures > test/fixtures/url-import.ts > isProduction is false 1`] = `
+"//vite-plugin-lit-css.js
+const s = \\"/styles.css\\", t = s;
+export {
+  t as styleUrl
+};
+
+styles.css"
+`;
+
+exports[`litcss plugin > fixtures > test/fixtures/url-import.ts > isProduction is true 1`] = `
+"//vite-plugin-lit-css.js
+const s = \\"/styles.css\\", t = s;
+export {
+  t as styleUrl
+};
+
+styles.css"
+`;

--- a/test/fixtures/url-import.ts
+++ b/test/fixtures/url-import.ts
@@ -1,0 +1,3 @@
+import cssUrl from './styles.css?url'
+
+export const styleUrl = cssUrl


### PR DESCRIPTION
Add support for detecting CSS imports with special query parameters (like ?url) that should bypass lit-css transformation and be handled by Vite's default CSS processing instead.

Without this change, the build would fail when a CSS file is requested with ?url.

A workaround I'm using for now is adding ` /[?&]transform-only\b/` in my exclude configuration, but that shouldn't be needed. It's not 100% clear to me what is `?transform-only`, I didn't see any information about it on vitejs documentation so I hope this is somewhat future-proof.

Tell me what you think!